### PR TITLE
Create individual Dockerfiles for each target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,31 @@
 version: 2
 updates:
 - package-ecosystem: "docker"
-  directory: "/x86_64"
+  directory: "/manylinux2014_x86_64"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "docker"
+  directory: "/manylinux2014_i686"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "docker"
+  directory: "/manylinux2014_aarch64"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "docker"
+  directory: "/manylinux2014_ppc64le"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "docker"
+  directory: "/manylinux2014_s390x"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "docker"
+  directory: "/musllinux_1_2_x86_64"
+  schedule:
+    interval: "daily"
+- package-ecosystem: "docker"
+  directory: "/musllinux_1_2_aarch64"
   schedule:
     interval: "daily"
 - package-ecosystem: "github-actions"

--- a/.github/workflows/manylinux2014_aarch64.yml
+++ b/.github/workflows/manylinux2014_aarch64.yml
@@ -1,0 +1,16 @@
+name: Build and publish manylinux2014_aarch64
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: 
+    - "main"
+    paths:
+    - "manylinux2014_aarch64/Dockerfile"
+
+jobs:
+  build-and-publish:
+    uses: "./.github/workflows/publish_docker.yml"
+    with:
+      imagename: "manylinux2014_aarch64"
+      platform: "linux/amd64"

--- a/.github/workflows/manylinux2014_aarch64.yml
+++ b/.github/workflows/manylinux2014_aarch64.yml
@@ -13,4 +13,4 @@ jobs:
     uses: "./.github/workflows/publish_docker.yml"
     with:
       imagename: "manylinux2014_aarch64"
-      platform: "linux/amd64"
+      platform: "linux/arm64/v8"

--- a/.github/workflows/manylinux2014_i686.yml
+++ b/.github/workflows/manylinux2014_i686.yml
@@ -1,0 +1,17 @@
+name: Build and publish manylinux2014_i686
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: 
+    - "main"
+    paths:
+    - "manylinux2014_i686/Dockerfile"
+
+jobs:
+  build-and-publish:
+    uses: "./.github/workflows/publish_docker.yml"
+    with:
+      dockerfile: "manylinux2014_i686/Dockerfile"
+      imagename: "manylinux2014_i686"
+      platform: "linux/386"

--- a/.github/workflows/manylinux2014_i686.yml
+++ b/.github/workflows/manylinux2014_i686.yml
@@ -12,6 +12,5 @@ jobs:
   build-and-publish:
     uses: "./.github/workflows/publish_docker.yml"
     with:
-      dockerfile: "manylinux2014_i686/Dockerfile"
       imagename: "manylinux2014_i686"
       platform: "linux/386"

--- a/.github/workflows/manylinux2014_ppc64le.yml
+++ b/.github/workflows/manylinux2014_ppc64le.yml
@@ -1,0 +1,16 @@
+name: Build and publish manylinux2014_ppc64le
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: 
+    - "main"
+    paths:
+    - "manylinux2014_ppc64le/Dockerfile"
+
+jobs:
+  build-and-publish:
+    uses: "./.github/workflows/publish_docker.yml"
+    with:
+      imagename: "manylinux2014_ppc64le"
+      platform: "linux/ppc64le"

--- a/.github/workflows/manylinux2014_s390x.yml
+++ b/.github/workflows/manylinux2014_s390x.yml
@@ -1,0 +1,16 @@
+name: Build and publish manylinux2014_s390x
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: 
+    - "main"
+    paths:
+    - "manylinux2014_s390x/Dockerfile"
+
+jobs:
+  build-and-publish:
+    uses: "./.github/workflows/publish_docker.yml"
+    with:
+      imagename: "manylinux2014_s390x"
+      platform: "linux/s390x"

--- a/.github/workflows/manylinux2014_x86_64.yml
+++ b/.github/workflows/manylinux2014_x86_64.yml
@@ -12,6 +12,5 @@ jobs:
   build-and-publish:
     uses: "./.github/workflows/publish_docker.yml"
     with:
-      dockerfile: "x86_64/Dockerfile"
       imagename: "manylinux2014_x86_64"
       platform: "linux/amd64"

--- a/.github/workflows/manylinux2014_x86_64.yml
+++ b/.github/workflows/manylinux2014_x86_64.yml
@@ -6,7 +6,7 @@ on:
     branches: 
     - "main"
     paths:
-    - "x86_64/Dockerfile"
+    - "manylinux2014_x86_64/Dockerfile"
 
 jobs:
   build-and-publish:

--- a/.github/workflows/manylinux2014_x86_64.yml
+++ b/.github/workflows/manylinux2014_x86_64.yml
@@ -1,0 +1,17 @@
+name: Build and publish manylinux2014_x86_64
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: 
+    - "main"
+    paths:
+    - "x86_64/Dockerfile"
+
+jobs:
+  build-and-publish:
+    uses: "./.github/workflows/publish_docker.yml"
+    with:
+      dockerfile: "x86_64/Dockerfile"
+      imagename: "manylinux2014_x86_64"
+      platform: "linux/amd64"

--- a/.github/workflows/musllinux_1_2_aarch64.yml
+++ b/.github/workflows/musllinux_1_2_aarch64.yml
@@ -1,0 +1,16 @@
+name: Build and publish musllinux_1_2_aarch64
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: 
+    - "main"
+    paths:
+    - "musllinux_1_2_aarch64/Dockerfile"
+
+jobs:
+  build-and-publish:
+    uses: "./.github/workflows/publish_docker.yml"
+    with:
+      imagename: "musllinux_1_2_aarch64"
+      platform: "linux/arm64/v8"

--- a/.github/workflows/musllinux_1_2_x86_64.yml
+++ b/.github/workflows/musllinux_1_2_x86_64.yml
@@ -1,0 +1,16 @@
+name: Build and publish musllinux_1_2_x86_64
+
+on: 
+  workflow_dispatch:
+  push:
+    branches: 
+    - "main"
+    paths:
+    - "musllinux_1_2_x86_64/Dockerfile"
+
+jobs:
+  build-and-publish:
+    uses: "./.github/workflows/publish_docker.yml"
+    with:
+      imagename: "musllinux_1_2_x86_64"
+      platform: "linux/amd64"

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -1,39 +1,27 @@
-name: Build and publish Docker images for devcontainer
+name: Build and publish Docker images
 
 on: 
-  workflow_dispatch:  
-  push:
-    branches: 
-    - "main"
-    paths: 
-    - "Dockerfile"
-    - "x86_64/Dockerfile" # triggered by dependabot ;)
-    # - ".github/workflows/publish_docker.yml"
+  workflow_call:   
+    inputs:
+      dockerfile:
+        description: 'Relative path to Dockerfile'
+        type: string
+        required: true
+      imagename:
+        description: 'Base name to use for uploaded image: E.g.: "manylinux2014_x86_64"'
+        type: string
+        required: true
+      platform:
+        description: 'Platform to build for. E.g.: "linux/amd64" or "linux/arm64/v8"'
+        type: string
+        required: true
 
 jobs:
   build-and-publish:
-    name: build ${{ matrix.baseImage }}
+    name: build ${{ inputs.dockerfile }}
     permissions:
       packages: write
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-        - baseImage: "manylinux2014_x86_64"
-          platform: "linux/amd64"
-        - baseImage: "manylinux2014_i686"
-          rustup_options: "--default-host i686-unknown-linux-gnu" # not correctly identified by rustup under QEMU on x64
-          platform: "linux/386"
-        - baseImage: "manylinux2014_aarch64"
-          platform: "linux/arm64/v8"
-        - baseImage: "manylinux2014_ppc64le"
-          platform: "linux/ppc64le"
-        - baseImage: "manylinux2014_s390x"
-          platform: "linux/s390x"
-        - baseImage: "musllinux_1_2_x86_64"
-          platform: "linux/amd64"
-        - baseImage: "musllinux_1_2_aarch64"
-          platform: "linux/arm64/v8"
 
     steps:
     - name: checkout
@@ -57,12 +45,9 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ${{ inputs.dockerfile }}
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        platforms: ${{ matrix.platform }}
-        build-args: |
-          baseImage=quay.io/pypa/${{ matrix.baseImage }}
-          rustup_options=${{ matrix.rustup_options }}
-        tags: ghcr.io/musicalninjas/${{ matrix.baseImage }}-rust
+        platforms: ${{ inputs.platform }}
+        tags: ghcr.io/musicalninjas/${{ inputs.imagename }}-rust

--- a/.github/workflows/publish_docker.yml
+++ b/.github/workflows/publish_docker.yml
@@ -3,10 +3,6 @@ name: Build and publish Docker images
 on: 
   workflow_call:   
     inputs:
-      dockerfile:
-        description: 'Relative path to Dockerfile'
-        type: string
-        required: true
       imagename:
         description: 'Base name to use for uploaded image: E.g.: "manylinux2014_x86_64"'
         type: string
@@ -18,7 +14,7 @@ on:
 
 jobs:
   build-and-publish:
-    name: build ${{ inputs.dockerfile }}
+    name: build ${{ inputs.imagename }}
     permissions:
       packages: write
     runs-on: ubuntu-latest
@@ -45,7 +41,7 @@ jobs:
     - name: Build and push
       uses: docker/build-push-action@v5
       with:
-        context: ${{ inputs.dockerfile }}
+        context: ${{ inputs.imagename }}
         push: true
         cache-from: type=gha
         cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,0 @@
-# Dependabot can't decode the yyyy-mm-dd-sha format used by cibuildwheel, so no point in restricting tags here.
-# (See https://github.com/pypa/cibuildwheel/discussions/1858)
-ARG baseImage=quay.io/pypa/manylinux2014_x86_64:2024.06.08-2
-FROM ${baseImage}
-
-ARG rustup_options=
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
-ENV PATH=/root/.cargo/bin:$PATH
-RUN cargo install just

--- a/manylinux2014_aarch64/Dockerfile
+++ b/manylinux2014_aarch64/Dockerfile
@@ -1,0 +1,7 @@
+ARG rustup_options=
+
+FROM quay.io/pypa/manylinux2014_aarch64:2024.06.09-5
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install just

--- a/manylinux2014_i686/Dockerfile
+++ b/manylinux2014_i686/Dockerfile
@@ -1,4 +1,5 @@
-ARG rustup_options=
+ARG rustup_options="--default-host i686-unknown-linux-gnu" 
+# not correctly identified by rustup under QEMU on x64
 
 FROM quay.io/pypa/manylinux2014_x86_64:2024.06.09-3
 

--- a/manylinux2014_i686/Dockerfile
+++ b/manylinux2014_i686/Dockerfile
@@ -1,7 +1,6 @@
-ARG rustup_options="--default-host i686-unknown-linux-gnu" 
-# not correctly identified by rustup under QEMU on x64
+ARG rustup_options=
 
-FROM quay.io/pypa/manylinux2014_i686:2024.06.09-4
+FROM quay.io/pypa/manylinux2014_x86_64:2024.06.09-3
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
 ENV PATH=/root/.cargo/bin:$PATH

--- a/manylinux2014_i686/Dockerfile
+++ b/manylinux2014_i686/Dockerfile
@@ -1,7 +1,7 @@
 ARG rustup_options="--default-host i686-unknown-linux-gnu" 
 # not correctly identified by rustup under QEMU on x64
 
-FROM quay.io/pypa/manylinux2014_x86_64:2024.06.09-3
+FROM quay.io/pypa/manylinux2014_i686:2024.06.09-3
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
 ENV PATH=/root/.cargo/bin:$PATH

--- a/manylinux2014_ppc64le/Dockerfile
+++ b/manylinux2014_ppc64le/Dockerfile
@@ -1,0 +1,7 @@
+ARG rustup_options=
+
+FROM quay.io/pypa/manylinux2014_ppc64le:2024.06.09-5
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install just

--- a/manylinux2014_s390x/Dockerfile
+++ b/manylinux2014_s390x/Dockerfile
@@ -1,0 +1,7 @@
+ARG rustup_options=
+
+FROM quay.io/pypa/manylinux2014_s390x:2024.06.09-5
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install just

--- a/manylinux2014_x86_64/Dockerfile
+++ b/manylinux2014_x86_64/Dockerfile
@@ -1,6 +1,6 @@
 ARG rustup_options=
 
-FROM quay.io/pypa/manylinux2014_i686:2024.06.09-4
+FROM quay.io/pypa/manylinux2014_x86_64:2024.06.09-4
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
 ENV PATH=/root/.cargo/bin:$PATH

--- a/manylinux2014_x86_64/Dockerfile
+++ b/manylinux2014_x86_64/Dockerfile
@@ -1,8 +1,7 @@
-# Dependabot can't decode the yyyy-mm-dd-sha format used by cibuildwheel, so no point in restricting tags here.
-# (See https://github.com/pypa/cibuildwheel/discussions/1858)
+ARG rustup_options=
+
 FROM quay.io/pypa/manylinux2014_x86_64:2024.06.09-3
 
-ARG rustup_options=
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
 ENV PATH=/root/.cargo/bin:$PATH
 RUN cargo install just

--- a/manylinux2014_x86_64/Dockerfile
+++ b/manylinux2014_x86_64/Dockerfile
@@ -1,5 +1,4 @@
-ARG rustup_options="--default-host i686-unknown-linux-gnu" 
-# not correctly identified by rustup under QEMU on x64
+ARG rustup_options=
 
 FROM quay.io/pypa/manylinux2014_i686:2024.06.09-4
 

--- a/musllinux_1_2_aarch64/Dockerfile
+++ b/musllinux_1_2_aarch64/Dockerfile
@@ -1,0 +1,7 @@
+ARG rustup_options=
+
+FROM quay.io/pypa/musllinux_1_2_aarch64:2024.06.09-5
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install just

--- a/musllinux_1_2_x86_64/Dockerfile
+++ b/musllinux_1_2_x86_64/Dockerfile
@@ -1,0 +1,7 @@
+ARG rustup_options=
+
+FROM quay.io/pypa/musllinux_1_2_x86_64:2024.06.09-4
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal ${rustup_options}
+ENV PATH=/root/.cargo/bin:$PATH
+RUN cargo install just


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request refactors the CI workflows to create individual Dockerfiles for each target platform. It introduces separate workflows for each platform, making the build and publish process more modular and maintainable.

* **CI**:
    - Refactored the Docker image build and publish workflow to use individual Dockerfiles for each target platform.
    - Updated the CI configuration to use workflow inputs for image name and platform, allowing for more flexible and reusable workflows.
    - Added separate CI workflows for each target platform, including manylinux2014_x86_64, manylinux2014_i686, manylinux2014_aarch64, manylinux2014_ppc64le, manylinux2014_s390x, musllinux_1_2_x86_64, and musllinux_1_2_aarch64.

<!-- Generated by sourcery-ai[bot]: end summary -->